### PR TITLE
Creating keyword Conceal Logs For Password

### DIFF
--- a/src/CryptoLibrary/__init__.py
+++ b/src/CryptoLibrary/__init__.py
@@ -147,6 +147,11 @@ THIS IS JUST AN ALPHA VERSION !!11!!1
         self.variable_decryption = variable_decryption
         self.builtin = BuiltIn()
 
+    def conceal_logs_for_password(self, plaintext):
+        """Conceal logs for the password passed as input."""
+        logger.info(f'Conceal logs for the password passed as input')
+        self.value_list.append(plaintext)
+
     def decrypt_text_to_variable(self, variable_name, cipher_text):
         """Decrypts cipher_text and stores the decrypted plain text into a scalar variable.
         Variable would be i.e. ${variable_name}"""


### PR DESCRIPTION
It could be useful to conceal passwords which are stored in other vaults.
Working from some tests:
![image](https://user-images.githubusercontent.com/20927198/72886790-bbec1500-3d0a-11ea-94ab-f44e02564cff.png)
